### PR TITLE
Add missing scene attribute _los_factors in scene.py

### DIFF
--- a/src/scene.py
+++ b/src/scene.py
@@ -417,6 +417,7 @@ class BaseScene(object):
         self._displacement = None
         self._phi = None
         self._theta = None
+        self._los_factors = None
         self.cols = 0
         self.rows = 0
         self.los = LOSUnitVectors(scene=self)


### PR DESCRIPTION
Fix error: "Scene object has no attribute '_los_factors'", when calling scene.los_rotation_factors