### PR TITLE
stamps2kite fix look angle interpolation

### DIFF
--- a/src/util/stamps2kite.py
+++ b/src/util/stamps2kite.py
@@ -147,7 +147,7 @@ def interpolate_look_angles(data):
               data.px_width, data.px_length)
     log.debug('Radar coordinates data: length %d - %d; width %d - %d',
               data.radar_coords[1].min(), data.radar_coords[1].max(),
-              data.radar_coords[0].min(), data.radar_coords[0].max())
+              data.radar_coords[2].min(), data.radar_coords[2].max())
     log.debug('Binned radar coordinate ranges: length %d - %d; width %d - %d',
               num.nanmin(data.bin_radar_i), num.nanmax(data.bin_radar_i),
               num.nanmin(data.bin_radar_j), num.nanmax(data.bin_radar_j))
@@ -158,7 +158,7 @@ def interpolate_look_angles(data):
         .reshape(2, 2500)
 
     radar_coords = num.vstack(
-        [data.bin_radar_j.ravel() - data.radar_coords[0].min(),
+        [data.bin_radar_j.ravel() - data.radar_coords[2].min(),
          data.bin_radar_i.ravel() - data.radar_coords[1].min()])
 
     interp = interpolate.LinearNDInterpolator(coords.T, data.look_angles)

--- a/src/util/stamps2kite.py
+++ b/src/util/stamps2kite.py
@@ -162,8 +162,18 @@ def interpolate_look_angles(data):
          data.bin_radar_i.ravel() - data.radar_coords[1].min()])
 
     interp = interpolate.LinearNDInterpolator(coords.T, data.look_angles)
-    data.bin_look_angles = interp(radar_coords.T).reshape(
+    bin_look_angles = interp(radar_coords.T).reshape(
         *data.bin_ps_mean_v.shape)
+
+    npix_missing_la = num.isnan(
+        bin_look_angles[~num.isnan(data.bin_ps_mean_v)]).sum()
+
+    if npix_missing_la:
+        log.warning(
+            'Found %i pixels in displacements that have no look angle'
+            ' information! This may result in errors later!' % npix_missing_la)
+
+    data.bin_look_angles = bin_look_angles
     return interp
 
 


### PR DESCRIPTION
Fix a radar coords indexing Bug that caused erroneous look-angle interpolation while importing data from stamps to kite.