### PR TITLE
fix clients.py; replace "http" with "https" when defining `los_url`

### DIFF
--- a/src/clients.py
+++ b/src/clients.py
@@ -41,7 +41,7 @@ def download_licsar(unw_url, destination='.'):
     for unit in ('E', 'N', 'U'):
         fn = '%s.geo.%s.tif' % (scene_id, unit)
         los_url = op.join(meta_url, fn)
-        los_url = re.sub(r'^(http:/)\b', r'\1/', los_url, 0)
+        los_url = re.sub(r'^(https:/)\b', r'\1/', los_url, 0)
         outfn = op.normpath(op.join(destination, fn))
 
         _download_file(los_url, outfn)


### PR DESCRIPTION
Hello 👋 I encountered the following `InvalidURL` error when downloading metadata (LOS angles) of LiCSAR products. 

### Test
```python
from kite import clients
unw_url = 'https://gws-access.jasmin.ac.uk/public/nceo_geohazards/LiCSAR_products/131/131A_05153_131313/interferograms/20201024_20201030/20201024_20201030.geo.unw.tif'
clients.download_licsar(unw_url=unw_url, destination='__data')
```

### Error
```python
InvalidURL: Invalid URL 'https:/gws-access.jasmin.ac.uk/public/nceo_geohazards/LiCSAR_products/131/131A_05153_131313/metadata/131A_05153_131313.geo.E.tif': No host supplied
```

This can be fixed by replacing `http` with `https`. Please see the code change in `src/clients.py`. It would be great if you could consider this very minor pull request. Thanks 🙏 