### PR TITLE
Add support to install kite system-native on current Ubuntu and Debian distros

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -3,35 +3,43 @@ Installation
 
 Kite is written for `Python 3 <https://python.org>`_, the installation has been tested on Debian based distributions (e.g. Ubuntu and Mint), MacOSX, and `Anaconda <https://anaconda.org/pyrocko/kite>`_.
 
-Debian / Ubuntu
----------------
+System-wide installation on Debian / Ubuntu
+-------------------------------------------
 
 As a mandatory prerequisite you have to install Pyrocko, visit `Pyrocko installation instructions <https://pyrocko.org/docs/current/install/index.html>`_ for details.
 
 .. code-block :: sh
     :caption: Installation from source and ``apt-get``
 
-    sudo apt-get install python3-dev python3-pyqt5 python3-pyqt5 python3-pyqt5.qtopengl python3-scipy python3-numpy python3-pyqtgraph
+    # satisfy Kite's requirements with system packages
+    sudo apt-get install python3-dev python3-pyqt5 python3-pyqt5 python3-pyqt5.qtopengl python3-scipy python3-numpy python3-pyqtgraph python3-geojson python3-setuptools python3-setuptools-scm
 
-    git clone https://github.com/Turbo87/utm
-    cd utm
-    sudo python3 setup.py install
+    # install the utm package with pip (no system package available)
+    sudo pip3 install utm
 
+   # get Kite's source code with git
     git clone https://github.com/pyrocko/kite
     cd kite
-    sudo python3 setup.py install
+
+    # compile and install with pip, but disable automatic dependency resolution (--no-deps)
+    sudo pip3 install . --no-build-isolation --no-deps
 
 
-PIP
----
-
-An installation through ``pip`` requires the same prerequisites as above:
+Installation with ``pip`` into virtual environment ``venv``
+-----------------------------------------------------------
 
 .. code-block :: sh
-    :caption: Installation through pip
+    :caption: Installation into venv
 
-    sudo pip3 install utm
-    sudo pip3 install git+https://github.com/pyrocko/kite
+   # create and activate venv
+   python3 -m venv venv
+   source venv/bin/activate
+
+   # get Kite's source code with git
+   git clone https://github.com/pyrocko/kite
+   cd kite
+   # install prerequisites with pip, compile and install Kite
+   pip install .
 
 
 MacOS (Sierra, MacPorts)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [build-system]
 requires = [
   "wheel",
-  "setuptools >= 61.0.0",
+  "setuptools >= 52.0.0",
   "oldest-supported-numpy",
-  "setuptools_scm[toml]>=6.2",
+  "setuptools_scm[toml]>=5.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -34,9 +34,9 @@ classifiers = [
 ]
 dependencies = [
   "numpy>=1.17.3",
-  "scipy>=1.8.0",
-  "PyQt5>=5.15.7",
-  "pyqtgraph==0.12.4",
+  "scipy>=1.6.0",
+  "PyQt5>=5.15.0",
+  "pyqtgraph==0.11.0",
   "pyrocko>=2022.06.10",
   "utm>=0.7.0",
   "geojson>=2.5.0",
@@ -48,7 +48,7 @@ GitHub = "https://github.com/pyrocko/kite"
 Issues = "https://github.com/pyrocko/kite/issues"
 
 [project.optional-dependencies]
-gdal = ["gdal>=3.5.0"]
+gdal = ["gdal>=3.2.0"]
 development = ["flake8", "black", "pre-commit"]
 tests = ["pytest"]
 


### PR DESCRIPTION
- this PR downgrades the overly aggressive version requirements on pyqt, scipy, pyqtgraph, setuptools, setuptools_scm and gdal
- adds a fallback to setup.py so that install is possible with setuptools lacking support for pep621 AS IS THE CASE FOR SYSTEM PACKAGED SETUPTOOLS e.g. ON UBUNTU 22.04 (2023-05-08).
- updates installation docs