### PR TITLE
Fix installation issues and compatibility with current pyrocko and pyqtgraph

### DIFF
--- a/kite/scene.py
+++ b/kite/scene.py
@@ -8,7 +8,7 @@ from datetime import datetime as dt
 
 import numpy as np
 import utm
-from pyrocko.dataset.topo import srtmgl3
+from pyrocko.dataset import topo
 from pyrocko.guts import Dict, Float, Object, String, StringChoice, Timestamp, load
 from pyrocko.orthodrome import latlon_to_ne, latlon_to_ne_numpy, ne_to_latlon  # noqa
 from scipy import interpolate
@@ -643,6 +643,7 @@ class BaseScene(object):
         return self._los_factors
 
     def get_elevation(self, interpolation="nearest_neighbor"):
+        srtmgl3 = topo.dem("SRTMGL3")
         assert interpolation in ("nearest_neighbor", "bivariate")
 
         if self._elevation.get(interpolation, None) is None:

--- a/kite/spool/base.py
+++ b/kite/spool/base.py
@@ -3,7 +3,7 @@ from os import path
 import numpy as np
 import pyqtgraph as pg
 import pyqtgraph.parametertree.parameterTypes as pTypes
-from PyQt5 import QtCore
+from PyQt5 import QtCore, QtGui
 from pyqtgraph import dockarea
 
 from kite.qt_utils import _viridis_data
@@ -17,6 +17,12 @@ d2r = np.pi / 180.0
 
 def get_resource(filename):
     return path.join(path.dirname(path.realpath(__file__)), "res", filename)
+
+
+def set_scale(image, width, height):
+    tr = QtGui.QTransform()
+    tr.scale(width, height)
+    image.setTransform(tr)
 
 
 class KiteView(dockarea.DockArea):
@@ -239,13 +245,13 @@ class KitePlot(pg.PlotWidget):
             None, autoDownsample=False, border=None, useOpenGL=False
         )
         hillshade.resetTransform()
-        hillshade.scale(frame.dE, frame.dN)
+        set_scale(hillshade, frame.dE, frame.dN)
 
         elev_img = pg.ImageItem(
             None, autoDownsample=False, border=None, useOpenGL=False
         )
         elev_img.resetTransform()
-        elev_img.scale(frame.dE, frame.dN)
+        set_scale(elev_img, frame.dE, frame.dN)
 
         elev_img.updateImage(elevation.T, autoLevels=True)
         hillshade.updateImage(shad.T, autoLevels=True)
@@ -269,7 +275,7 @@ class KitePlot(pg.PlotWidget):
         frame = self.model.frame
 
         self.image.resetTransform()
-        self.image.scale(frame.dE, frame.dN)
+        set_scale(self.image, frame.dE, frame.dN)
 
     def scalebar(self):
         """Not working"""
@@ -437,12 +443,12 @@ class KiteParameterGroup(pTypes.GroupParameter):
         self.model = model
         self.model_attr = model_attr
 
+        pTypes.GroupParameter.__init__(self, **kwargs)
         self.parameters = getattr(self, "parameters", [])
 
         if isinstance(self.parameters, list):
             self.parameters = dict.fromkeys(self.parameters)
 
-        pTypes.GroupParameter.__init__(self, **kwargs)
         self.updateValues()
 
     def updateValues(self):

--- a/kite/spool/spool.py
+++ b/kite/spool/spool.py
@@ -202,7 +202,7 @@ class SpoolMainWindow(QtWidgets.QMainWindow):
 
         self.progress.setWindowTitle("Processing...")
         self.progress.setLabelText(text)
-        self.progress.setMaximum(maximum)
+        self.progress.setMaximum(int(maximum))
         self.progress.setValue(0)
 
         @QtCore.pyqtSlot()

--- a/kite/spool/tab_covariance.py
+++ b/kite/spool/tab_covariance.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 import numpy as np
 import pyqtgraph as pg
 import pyqtgraph.parametertree.parameterTypes as pTypes
-from PyQt5 import QtCore, QtWidgets
+from PyQt5 import QtCore, QtGui, QtWidgets
 from pyqtgraph import dockarea
 
 from kite.covariance import CovarianceConfig
@@ -24,6 +24,12 @@ pen_green_dash = pg.mkPen((115, 210, 22), width=2.5, style=QtCore.Qt.DashLine)
 
 pen_roi = pg.mkPen((78, 154, 6), width=2)
 pen_roi_highlight = pg.mkPen((115, 210, 22), width=2, style=QtCore.Qt.DashLine)
+
+
+def set_rotate(item, angle):
+    tr = QtGui.QTransform()
+    tr.rotate(angle)
+    item.setTransform(tr)
 
 
 class KiteCovariance(KiteView):
@@ -477,7 +483,7 @@ class KiteToolNoise(QtWidgets.QDialog):
                 ge.hist_syn.setData(*h)
 
             ge.hist_syn = pg.PlotDataItem(pen=hist_pen)
-            ge.hist_syn.rotate(90.0)
+            set_rotate(ge.hist_syn, 90.0)
             ge.vb.addItem(ge.hist_syn)
             updateHistogram()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "numpy>=1.17.3",
   "scipy>=1.6.0",
   "PyQt5>=5.15.0",
-  "pyqtgraph==0.11.0",
+  "pyqtgraph>=0.11.0",
   "pyrocko>=2022.06.10",
   "utm>=0.7.0",
   "geojson>=2.5.0",

--- a/setup.py
+++ b/setup.py
@@ -172,7 +172,9 @@ if not have_pep621_support:
         ],
     }
 else:
-    metadata = {}
+    metadata = dict(
+        ext_package="kite",
+    )
 
 
 setup(


### PR DESCRIPTION
Should fix #113.

Tested in a pip env with `--system-site-packages` on Ubuntu 22.04 and system installed pyqtgraph, qt5, etc.

Isolated pip env install is still broken because of incompatibility with newer pyqtpgraph. Simple downgrading of pyqtgraph did not help because of incompatibilities between pyqtpgraph/qt5/numpy.